### PR TITLE
Addition of Image upload and deletion api 

### DIFF
--- a/backend/app/API/image.py
+++ b/backend/app/API/image.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException
 from app.services import yolo_service, s3_service, dynamodb_service_image
 from datetime import datetime
-
+import uuid
 
 router = APIRouter()
 
@@ -9,7 +9,9 @@ router = APIRouter()
 async def upload_image(employee_id: str = Form(...),file: UploadFile = File(...)):
     # Step 1: Save temporarily & run YOLO
     # This returns the raw content of the file in bytes, not a file path or an image object.
-    tags = yolo_service.detect_objects(await file.read())
+    content=await file.read()
+    size = len(content)  # image size in bytes
+    tags = yolo_service.detect_objects(content)
 
     # Step 2: Upload image to S3
     #  If the file was read before (e.g., await file.read() for YOLO), the internal pointer
@@ -18,19 +20,25 @@ async def upload_image(employee_id: str = Form(...),file: UploadFile = File(...)
     
     file.file.seek(0)  # reset file pointer
     filename = f"{employee_id}/{uuid.uuid4()}.jpg"
-    s3_url = s3_service.upload_to_s3(file.file, filename)
+    s3_location = s3_service.upload_to_s3(file.file, filename)
 
-    # Step 3: Save metadata to DynamoDB
+    # Step 3: Save metadata to DynamoDB_service_image
     metadata = {
-        "image_id": str(uuid.uuid4()),
         "employee_id": employee_id,
         "upload_time": datetime.utcnow().isoformat(),
-        "s3_url": s3_url,
-        "tags": tags
+        "s3_location": s3_location,
+        "tags": tags,
+        "size": size
     }
-    dynamodb_service.save_image_metadata(metadata)
+    dynamodb_service_image.save_image_metadata(metadata)
 
-    return {"message": "Image uploaded", "tags": tags, "s3_url": s3_url}
+    return {"message": "Image uploaded", "tags": tags, "s3_location": s3_location}
+
+@router.delete("/image/delete")
+def delete_image(employee_id: str, s3_location: str):
+    s3_service.delete_from_s3(s3_location)
+    dynamodb_service_image.delete_image_metadata(employee_id, s3_location)
+    return {"message": "Image deleted successfully"}
 
 
 

--- a/backend/app/models/images.py
+++ b/backend/app/models/images.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class ImageMetadata(BaseModel):
+    employee_id: str
+    upload_time: str  # ISO formatted string (can be datetime too)
+    s3_location: str
+    tags: list[str]
+    size: int  # in bytes or kilobytes depending on your use case

--- a/backend/app/services/dynamodb_service.py
+++ b/backend/app/services/dynamodb_service.py
@@ -26,8 +26,6 @@ table = dynamodb.Table('team-alpha-ai')
 
 user_id = "Oudarja_Tanmoy"
 
-employee_info=[]
-
 # Create item (C)
  # employee_info = [
     #     {'employee_id': 'E000',

--- a/backend/app/services/dynamodb_service_image.py
+++ b/backend/app/services/dynamodb_service_image.py
@@ -1,0 +1,92 @@
+# Business logic for DynamoDB
+# These are called from your API routers in api/employee.py, api/image.py, etc.
+from dotenv import load_dotenv
+import os
+import boto3
+from datetime import datetime
+from app.models.employee import EmployeeCreate
+from app.models.images import  ImageMetadata
+# Load environment variables from .env file
+load_dotenv()
+
+# Get credentials from environment
+aws_key = os.getenv("AWS_ACCESS_KEY_ID")
+aws_secret = os.getenv("AWS_SECRET_ACCESS_KEY")
+aws_region = os.getenv("AWS_REGION")
+
+# Create DynamoDB resource
+dynamodb = boto3.resource(
+    'dynamodb',
+    aws_access_key_id=aws_key,
+    aws_secret_access_key=aws_secret,
+    region_name=aws_region
+)
+
+# Use the table
+table = dynamodb.Table('team-alpha-ai')
+
+user_id = "Tanmoy_images"
+
+def save_image_metadata(metadata: dict):
+     # Optional: Validate and convert dict to Pydantic model
+     validated_metadata = ImageMetadata(**metadata)
+     response = table.get_item(Key={'id': user_id})
+     
+     # Check if the 'Item' exists in the response
+     if 'Item' not in response:
+        # If no item exists, initialize an empty employee list for the user
+        item = {'id': user_id, 'images_data': []}
+     else:
+        # If item exists, use the existing employee data
+        item = response['Item']
+    
+     image_metadata=item['images_data']
+
+     image_metadata.append(validated_metadata.dict())
+
+     table.put_item(Item={
+        'id': user_id,  # Use your table's partition key
+        'images_data':image_metadata   # Could act as sort key if defined
+        })
+     return validated_metadata.dict()
+
+# Delete image bussiness logic 
+def delete_image_metadata(employee_id:str, s3_location:str):
+   response = table.get_item(Key={'id': user_id})
+
+   if 'Item' not in response:
+        raise ValueError("Employee ID not found in database")
+
+   item = response['Item']
+   images_data = item.get('images_data', [])
+   # Filter out the entry with the matching s3_key
+   updated_images = [img for img in images_data if img["s3_location"] != s3_location]
+
+   # Put updated item back
+   table.put_item(Item={
+        'id': user_id,
+        'images_data': updated_images
+   })
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+    
+
+    
+
+
+
+

--- a/backend/app/services/s3_service.py
+++ b/backend/app/services/s3_service.py
@@ -5,7 +5,7 @@
 import boto3
 from dotenv import load_dotenv
 import os
-
+import tempfile
 
 # Load environment variables from .env file
 load_dotenv()
@@ -23,7 +23,34 @@ s3 = boto3.client(
 )
 
 
-# Upload file
-def upload_to_s3():
-    # s3.upload_file(local_file_path, bucket_name, s3_folder)
-    s3.upload_file("example.jpg", "alpha-ai-new", "Oudarja_Barman_Tanmoy/example.jpg")
+# # Upload file
+# def upload_to_s3():
+#     # s3.upload_file(local_file_path, bucket_name, s3_folder)
+#     # s3.upload_file("example.jpg", "alpha-ai-new", "Oudarja_Barman_Tanmoy")
+
+def upload_to_s3(file_obj, filename):
+    # Save the file temporarily
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as temp:
+        temp.write(file_obj.read())
+        temp_path = temp.name
+
+    # Create full key/path inside the bucket
+    s3_key = f"Oudarja_Barman_Tanmoy/{filename}"
+
+    try:
+        # Upload to S3
+        s3.upload_file(temp_path,"alpha-ai-new", s3_key)
+    except Exception as e:
+        raise RuntimeError(f"Failed to upload to S3: {e}")
+    finally:
+        # Clean up the temp file
+        os.remove(temp_path)
+
+    # Return the S3 location (not a URL)
+    return f"alpha-ai-new/{s3_key}"
+
+# delete image bussiness logic from s3 
+def delete_from_s3(s3_location: str):
+    s3_location_stripped = s3_location[len("alpha-ai-new/"):]
+    s3.delete_object(Bucket="alpha-ai-new",Key=s3_location_stripped)
+

--- a/backend/app/services/yolo_service.py
+++ b/backend/app/services/yolo_service.py
@@ -1,18 +1,20 @@
 # Business logic for object detection
 from ultralytics import YOLO
 import tempfile
+import os
+
 
 # Load YOLO model only once (at module level)
 model = YOLO("yolov8n.pt")
 
-def detect_objects(image_bytes: bytes) -> List[str]:
+def detect_objects(image_bytes: bytes) -> list[str]:
     '''
     ->tempfile is used to temporarily save the uploaded file in memory before passing it to YOLO.
     ->model = YOLO("yolov8n.pt") is placed at the module level so it doesn’t reload every time.
     ->Returns a list of unique class names (e.g., ["person", "dog"]).
     '''
     # Save image temporarily for detection
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=True) as temp_image:
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as temp_image:
         # Write the incoming image data (image_bytes, likely from UploadFile.read())
         # into the temporary file.
         # YOLO needs to load images from disk (by path), so we need to save the bytes first.
@@ -26,19 +28,20 @@ def detect_objects(image_bytes: bytes) -> List[str]:
         # YOLOv8 runs inference (object detection) on the temp image.
         # results contains bounding boxes, class IDs, confidence scores, etc.
         # Run YOLOv8 model inference on the image saved at temp_image.name (the file path).
-        results = model(temp_image.name)
+    results = model(temp_image.name,conf=0.1)
+     # Optionally delete manually
+    os.remove(temp_image.name)
 
-        detected_classes = set()  # Use set to avoid duplicates
-
-        # Loop through results to collect class names
-        for result in results:
-            for box in result.boxes:
-                class_id = int(box.cls)
-                class_name = result.names[class_id]
-                detected_classes.add(class_name)
+    detected_classes = set()  # Use set to avoid duplicates
+     # Loop through results to collect class names
+    for result in results:
+        for box in result.boxes:
+            class_id = int(box.cls)
+            class_name = result.names[class_id]
+            detected_classes.add(class_name)
         
-        # Converts the set of class names to a list before returning it.
-        return list(detected_classes)
+    # Converts the set of class names to a list before returning it.
+    return list(detected_classes)
 
 '''
 The Ultralytics YOLO model expects:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,6 +33,7 @@ pydantic_core==2.33.2
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
+python-multipart==0.0.20
 pytz==2025.2
 PyYAML==6.0.2
 requests==2.32.3


### PR DESCRIPTION
This pull request introduces two new API endpoints for handling image operations in the backend:

- POST images/upload-image: Allows the client (admin) to upload an image. On successful upload, the image is stored in S3, and corresponding metadata (employee_id, tags, created_time, and s3_url) is saved in DynamoDB.

- DELETE /images/image/delete: Enables deletion of a specific image. This endpoint removes the image from S3 and deletes its metadata from DynamoDB.

Key Features:

- Integrated S3 for image storage

- Integrated DynamoDB for metadata storage

- Proper error handling and validation

- Modular code structure for easier testing and maintenance